### PR TITLE
Use a more appropriately sized arrow for nav dropdowns

### DIFF
--- a/src/theme/_uswds-theme-custom-styles.scss
+++ b/src/theme/_uswds-theme-custom-styles.scss
@@ -89,11 +89,11 @@ h1,h2,h3,h4,h5,h6,.usa-logo__text {
     .usa-nav__primary button[aria-expanded=false] {
         @include add-background-svg('plus-white');
         @include at-media($theme-header-min-width) {
-            @include add-background-svg('angle-arrow-down-white');
+            @include add-background-svg('usa-icons-bg/expand_more--white');
         }
         &:hover {
             @include at-media($theme-header-min-width) {
-                @include add-background-svg('angle-arrow-down-white');
+                @include add-background-svg('usa-icons-bg/expand_more--white');
             }
         }
     }        
@@ -101,7 +101,7 @@ h1,h2,h3,h4,h5,h6,.usa-logo__text {
     .usa-nav__primary button[aria-expanded=true] {
         @include add-background-svg('minus-white');
         @include at-media($theme-header-min-width) {
-            @include add-background-svg('angle-arrow-up-primary');
+            @include add-background-svg('usa-icons/expand_less');
             background-color: color('base-lighter');
             color: color('ink');
         }   


### PR DESCRIPTION
Use the inverse background variant of the same icon that USWDS uses, `expand_more` and `expand_less`.

The `angle-arrow-down` and `angle-arrow-up` icons that were used previously were too large and looked out of place.

# Before
![Screen Shot 2022-02-08 at 18 01 52](https://user-images.githubusercontent.com/728407/153090258-e3668a9b-161a-4c3a-9902-002e70aec6c1.png)

# After
![Screen Shot 2022-02-08 at 17 59 46](https://user-images.githubusercontent.com/728407/153090270-180ff48d-33c1-4be6-af54-966e608612c9.png)

