### PR TITLE
Fix nav dropdown expand arrow for uswds 2.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node-notifier": "^8.0.0",
     "postcss-csso": "^4.0.0",
     "sass": "^1.26.10",
-    "uswds": "^2.13.1",
+    "uswds": "^2.13.3",
     "uswds-gulp": "github:uswds/uswds-gulp"
   }
 }

--- a/src/theme/_uswds-theme-custom-styles.scss
+++ b/src/theme/_uswds-theme-custom-styles.scss
@@ -86,25 +86,23 @@ h1,h2,h3,h4,h5,h6,.usa-logo__text {
         border-top: none;
     }
 
-    .usa-nav__primary button[aria-expanded=false] {
-        @include add-background-svg('plus-white');
-        @include at-media($theme-header-min-width) {
-            @include add-background-svg('usa-icons-bg/expand_more--white');
-        }
-        &:hover {
-            @include at-media($theme-header-min-width) {
-                @include add-background-svg('usa-icons-bg/expand_more--white');
-            }
-        }
+    .usa-nav__primary button[aria-expanded=false] span::after {
+        background-color: color('white');
     }        
 
     .usa-nav__primary button[aria-expanded=true] {
-        @include add-background-svg('minus-white');
+        & span::after {
+            background-color: color('white');
+        }
+
         @include at-media($theme-header-min-width) {
-            @include add-background-svg('usa-icons/expand_less');
             background-color: color('base-lighter');
             color: color('ink');
-        }   
+
+            & span::after {
+                background-color: color('ink');
+            }
+        }
     }
 
     .usa-nav__primary>.usa-nav__primary-item>a:hover {


### PR DESCRIPTION
USWDS changed how they did the navbar icons, so we have to adjust how we achieve the white-on-black color scheme in order to update to USWDS 2.13.3.

Before this fix:
![Screen Shot 2022-07-14 at 21 53 26](https://user-images.githubusercontent.com/728407/179131194-e8f01fd5-67b2-4b3e-9bd8-69d655af41c3.png)

After this fix:
![Screen Shot 2022-07-14 at 21 54 03](https://user-images.githubusercontent.com/728407/179131236-89ddccc5-b734-4c78-85fc-8ebf6ec20f2f.png)

