### PR TITLE
Run `gulp init` on install, pack, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "init": "gulp init",
+    "prepare": "gulp init",
     "watch": "gulp watch",
     "release": "gulp release"
   },


### PR DESCRIPTION
Rename the npm `init` script to `prepare` so that it is run on intall, pack, etc. This makes nasawds installable from GitHub.

See https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-scripts