### PR TITLE
Remove font smoothing, deprecated in USWDS 3.5.0

### DIFF
--- a/src/theme/_uswds-theme-custom-styles.scss
+++ b/src/theme/_uswds-theme-custom-styles.scss
@@ -51,10 +51,6 @@ h1, h2, .usa-display, .usa-logo__text {
     letter-spacing: letter-spacing(-2);
 }
 
-h1,h2,h3,h4,h5,h6,.usa-logo__text {
-    @include add-knockout-font-smoothing;
-}
-
 .usa-intro {
     font-weight: font-weight('light');
 }


### PR DESCRIPTION
This fixes the following warning:

> Font smoothing was deprecated in USWDS 3.5.0.
> Please remove any references to it.